### PR TITLE
Update oce version in conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -68,7 +68,7 @@ dependencies:
 - nbformat=4.4.0=py27_0
 - notebook=5.0.0=py27_0
 - numpydoc=0.7.0=py27_0
-- oce::oce=0.18.1=1
+- oce::oce=0.18.3=3
 - openssl=1.0.2l=0
 - pandocfilters=1.4.2=py27_0
 - path.py=10.3.1=py27_0


### PR DESCRIPTION
A newer version of oce allows installing a newer version of pythonocc-core (0.18.1), which includes this bug fix:

https://github.com/tpaviot/pythonocc-core/commit/3d72ebaad776800554758afdefa0c21610c2eff9

Note: haven't tested yet