### PR TITLE
change Invert() -> Inverted() in Matrix.inverse()

### DIFF
--- a/cadquery/occ_impl/geom.py
+++ b/cadquery/occ_impl/geom.py
@@ -195,7 +195,7 @@ class Matrix:
 
     def inverse(self):
         
-        return Matrix(self.wrapped.Invert())
+        return Matrix(self.wrapped.Inverted())
     
     def multiply(self,other):
         


### PR DESCRIPTION
The first changes the matrix in place, while the second creates a new matrix.

Btw, I'd be interested in helping out with FreeCAD->OCC transition. I've been playing around with gettting cqparts to work in cq-editor, which requires cqparts working with the OCC fork.

Is there a todo list yet of what needs to be done on the OCC fork before it can be merged into the main cadquery repo?