### PR TITLE
add Volume method to Shape

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -462,6 +462,10 @@ class Shape(object):
     def Area(self):
         raise NotImplementedError
 
+    def Volume(self):
+        # when density == 1, mass == volume
+        return Shape.computeMass(self)
+
     def _apply_transform(self, T):
 
         return Shape.cast(BRepBuilderAPI_Transform(self.wrapped,


### PR DESCRIPTION
cqparts currently reads Volume from the wrapped object here:

https://github.com/fragmuffin/cqparts/blob/58b2273945e566d639e844777468ecb77381bb64/src/cqparts/utils/test.py#L38-L40

The wrapped object in this case is a `TopoDS_Shape`, which doesn't have a Volume property directly.